### PR TITLE
Add "when" DateTime input field

### DIFF
--- a/vitreen/app/forms.py
+++ b/vitreen/app/forms.py
@@ -1,9 +1,18 @@
 from flask.ext.wtf import Form
 from wtforms import StringField, SubmitField
+from wtforms.fields.html5 import DateTimeField
 from wtforms.validators import DataRequired
+from wtforms_components import DateRange
+from datetime import datetime
 
 class CreateEventForm(Form):
   tags  = StringField('Tags', validators=[DataRequired()])
   title = StringField('Title', validators=[DataRequired()])
   desc  = StringField('Description', validators=[DataRequired()])
+  when  = DateTimeField('When', default=datetime.now(), validators=[
+    DataRequired(), DateRange(
+        min=datetime(2000, 1, 1),
+        max=datetime.now()
+      )
+    ])
   submit = SubmitField('Submit')

--- a/vitreen/app/views.py
+++ b/vitreen/app/views.py
@@ -5,6 +5,7 @@ from .forms import CreateEventForm
 import requests
 import json
 import urlparse
+import time
 
 @app.route('/')
 @app.route('/index')
@@ -15,8 +16,12 @@ def index():
 def create_event():
   form = CreateEventForm()
   if form.validate_on_submit():
-    event_payload = {'what': form.title.data, 'tags': form.tags.data,
-        'data': form.desc.data}
+    event_payload = {
+        'what': form.title.data,
+        'when': time.mktime(form.when.data.timetuple()),
+        'tags': form.tags.data,
+        'data': form.desc.data
+      }
     post_request = requests.post(
         urlparse.urljoin(app.config['GRAPHITE_SERVER_URL'], 'events/'),
         data=json.dumps(event_payload)


### PR DESCRIPTION
Adds a new DateTime field for the "when" property on Graphite Events. Uses current date/time by default, and validation ensures users cannot create events in the future or too far into the past. Brought in new `wtforms_components` dependency for the validation ([DateRange](https://wtforms-components.readthedocs.org/en/latest/#daterange-validator)).
